### PR TITLE
fix: ics and csv download filename is cut on chrome and edge

### DIFF
--- a/app/lib/string/escapeFilenameSpecialChars.ts
+++ b/app/lib/string/escapeFilenameSpecialChars.ts
@@ -1,5 +1,5 @@
 export function escapeFilenameSpecialChars(filename: string) {
-  const regex = /[^\t\x20-\x7e\x80-\xff]/g;
+  const regex = /[^\x20\x2e0-9A-Za-z]/g;
   const subst = "";
   const result = filename.replace(regex, subst);
   return result;

--- a/app/routes/event/$slug/ics-download.tsx
+++ b/app/routes/event/$slug/ics-download.tsx
@@ -4,7 +4,6 @@ import { LoaderFunction } from "remix";
 import { forbidden } from "remix-utils";
 import { getUserByRequestOrThrow } from "~/auth.server";
 import { escapeFilenameSpecialChars } from "~/lib/string/escapeFilenameSpecialChars";
-import { fromUTF8Array, toUTF8Array } from "~/lib/string/toUTF8Array";
 import { getParamValueOrThrow } from "~/lib/utils/routes";
 import {
   deriveMode,


### PR DESCRIPTION
## List issues that are affected

see #676 
