### PR TITLE
fix: profile deletion if privileged members exist

### DIFF
--- a/app/profile.server.ts
+++ b/app/profile.server.ts
@@ -404,7 +404,7 @@ export async function getFilteredProfiles(
   return result;
 }
 
-export async function getOrganisationsOnProfileByUserId(id: string) {
+export async function getRelationsOnProfileByUserId(id: string) {
   return await prismaClient.profile.findUnique({
     where: { id },
     select: {
@@ -414,6 +414,44 @@ export async function getOrganisationsOnProfileByUserId(id: string) {
           organization: {
             select: {
               name: true,
+              teamMembers: {
+                select: {
+                  isPrivileged: true,
+                  profileId: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      teamMemberOfEvents: {
+        select: {
+          isPrivileged: true,
+          event: {
+            select: {
+              name: true,
+              teamMembers: {
+                select: {
+                  isPrivileged: true,
+                  profileId: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      teamMemberOfProjects: {
+        select: {
+          isPrivileged: true,
+          project: {
+            select: {
+              name: true,
+              teamMembers: {
+                select: {
+                  isPrivileged: true,
+                  profileId: true,
+                },
+              },
             },
           },
         },

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -17,6 +17,7 @@ import {
   useLocation,
 } from "@remix-run/react";
 import * as React from "react";
+import { notFound } from "remix-utils";
 import { getFullName } from "~/lib/profile/getFullName";
 import { createAuthClient, getSessionUser } from "./auth.server";
 import Footer from "./components/Footer/Footer";
@@ -73,20 +74,24 @@ export const loader: LoaderFunction = async (args) => {
 
     let avatar: string | undefined;
 
-    if (profile && profile.avatar) {
-      const publicURL = getPublicURL(authClient, profile.avatar);
-      if (publicURL) {
-        avatar = getImageURL(publicURL, {
-          resize: { type: "fill", width: 64, height: 64 },
-        });
+    if (profile) {
+      sessionUserInfo = {
+        username: profile.username,
+        initials: getInitials(profile),
+        name: getFullName(profile),
+        avatar,
+      };
+      if (profile.avatar) {
+        const publicURL = getPublicURL(authClient, profile.avatar);
+        if (publicURL) {
+          avatar = getImageURL(publicURL, {
+            resize: { type: "fill", width: 64, height: 64 },
+          });
+        }
       }
+    } else {
+      throw notFound({ message: "profile not found." });
     }
-    sessionUserInfo = {
-      username: profile.username,
-      initials: getInitials(profile),
-      name: getFullName(profile),
-      avatar,
-    };
   }
 
   return json<LoaderData>(


### PR DESCRIPTION
Profile can now be deleted when other privileged members exist on connected organizations/events/projects

It can not be deleted when you're the last privileged member of an organization/event/project.

Also fixed bug: Not being redirected and logged out after profile deletion

## List issues that are affected

see #735 
