### PR TITLE
feat: remove/migrate target group elementary school

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# dumps
+/dump.sql
+
 # npm
 node_modules
 

--- a/prisma/scripts/import-datasets/data/targetGroups.json
+++ b/prisma/scripts/import-datasets/data/targetGroups.json
@@ -6,12 +6,6 @@
     "id": "f66f6052-2ad7-4726-bc98-75d47b237b76"
   },
   {
-    "referenceId": 729,
-    "title": "Grundschule",
-    "slug": "elementary_school",
-    "id": "646c5323-2b9f-40be-a284-9b13d673bc1c"
-  },
-  {
     "referenceId": 1297,
     "title": "Hochschulbildung",
     "slug": "hochschulbildung",

--- a/prisma/scripts/update-targetgroups/index.ts
+++ b/prisma/scripts/update-targetgroups/index.ts
@@ -1,0 +1,106 @@
+import { prismaClient } from "~/prisma.server";
+
+const ELEMENTARY = "646c5323-2b9f-40be-a284-9b13d673bc1c";
+const PRIMARY = "cbbc8772-8de9-41d5-ac13-b46bf9daafed";
+
+async function removeTargetGroupElementary() {
+  console.log(`Delete target group elementary school`);
+  const result = await prismaClient.targetGroup.deleteMany({
+    where: {
+      id: ELEMENTARY,
+    },
+  });
+
+  return result.count;
+}
+
+async function updateEvents() {
+  console.log(`Select all events with elementary school target group`);
+  const eventsWithElementarySchool = await prismaClient.event.findMany({
+    include: { targetGroups: true },
+    where: {
+      targetGroups: {
+        some: {
+          targetGroupId: ELEMENTARY,
+        },
+      },
+    },
+  });
+
+  eventsWithElementarySchool.forEach(async (event) => {
+    const isEventWithPrimaryTargetGroup = event.targetGroups.some(
+      (tg) => tg.targetGroupId === PRIMARY
+    );
+
+    if (!isEventWithPrimaryTargetGroup) {
+      console.log(
+        `Adding missing primary school to event ${event.id} ${event.name}`
+      );
+      await prismaClient.event.update({
+        where: {
+          id: event.id,
+        },
+        data: {
+          targetGroups: {
+            create: {
+              targetGroupId: PRIMARY,
+            },
+          },
+        },
+      });
+    }
+  });
+}
+
+async function updateProjects() {
+  console.log(`Select all projects with elementary school target group`);
+  const projectsWithElementarySchool = await prismaClient.project.findMany({
+    include: { targetGroups: true },
+    where: {
+      targetGroups: {
+        some: {
+          targetGroupId: ELEMENTARY,
+        },
+      },
+    },
+  });
+
+  projectsWithElementarySchool.forEach(async (project) => {
+    const isProjectWithPrimaryTargetGroup = project.targetGroups.some(
+      (tg) => tg.targetGroupId === PRIMARY
+    );
+
+    if (!isProjectWithPrimaryTargetGroup) {
+      console.log(
+        `Adding missing primary school to project ${project.id} ${project.name}`
+      );
+      await prismaClient.project.update({
+        where: {
+          id: project.id,
+        },
+        data: {
+          targetGroups: {
+            create: {
+              targetGroupId: PRIMARY,
+            },
+          },
+        },
+      });
+    }
+  });
+}
+
+async function main() {
+  console.log(`Update Events`);
+  await updateEvents();
+
+  console.log(`Update Projects`);
+  await updateProjects();
+
+  console.log(`Update TargetGroups`);
+  await removeTargetGroupElementary();
+
+  console.log("Done.");
+}
+
+main().catch(console.error);

--- a/prisma/scripts/update-targetgroups/index.ts
+++ b/prisma/scripts/update-targetgroups/index.ts
@@ -4,7 +4,6 @@ const ELEMENTARY = "646c5323-2b9f-40be-a284-9b13d673bc1c";
 const PRIMARY = "cbbc8772-8de9-41d5-ac13-b46bf9daafed";
 
 async function removeTargetGroupElementary() {
-  console.log(`Delete target group elementary school`);
   const result = await prismaClient.targetGroup.deleteMany({
     where: {
       id: ELEMENTARY,
@@ -15,92 +14,110 @@ async function removeTargetGroupElementary() {
 }
 
 async function updateEvents() {
-  console.log(`Select all events with elementary school target group`);
-  const eventsWithElementarySchool = await prismaClient.event.findMany({
-    include: { targetGroups: true },
-    where: {
-      targetGroups: {
-        some: {
-          targetGroupId: ELEMENTARY,
-        },
-      },
-    },
-  });
-
-  eventsWithElementarySchool.forEach(async (event) => {
-    const isEventWithPrimaryTargetGroup = event.targetGroups.some(
-      (tg) => tg.targetGroupId === PRIMARY
-    );
-
-    if (!isEventWithPrimaryTargetGroup) {
-      console.log(
-        `Adding missing primary school to event ${event.id} ${event.name}`
-      );
-      await prismaClient.event.update({
-        where: {
-          id: event.id,
-        },
-        data: {
-          targetGroups: {
-            create: {
-              targetGroupId: PRIMARY,
-            },
+  try {
+    console.log(`Select all events with elementary school target group`);
+    const eventsWithElementarySchool = await prismaClient.event.findMany({
+      include: { targetGroups: true },
+      where: {
+        targetGroups: {
+          some: {
+            targetGroupId: ELEMENTARY,
           },
         },
-      });
+      },
+    });
+
+    for (const event of eventsWithElementarySchool) {
+      const isEventWithPrimaryTargetGroup = event.targetGroups.some(
+        (tg) => tg.targetGroupId === PRIMARY
+      );
+
+      if (!isEventWithPrimaryTargetGroup) {
+        console.log(
+          `Adding missing primary school to event ${event.id} ${event.name}`
+        );
+
+        await prismaClient.event.update({
+          where: {
+            id: event.id,
+          },
+          data: {
+            targetGroups: {
+              create: {
+                targetGroupId: PRIMARY,
+              },
+            },
+          },
+        });
+      }
     }
-  });
+  } catch (error) {
+    console.error(`Error updating events: ${error}`);
+    throw error;
+  }
 }
 
 async function updateProjects() {
-  console.log(`Select all projects with elementary school target group`);
-  const projectsWithElementarySchool = await prismaClient.project.findMany({
-    include: { targetGroups: true },
-    where: {
-      targetGroups: {
-        some: {
-          targetGroupId: ELEMENTARY,
-        },
-      },
-    },
-  });
-
-  projectsWithElementarySchool.forEach(async (project) => {
-    const isProjectWithPrimaryTargetGroup = project.targetGroups.some(
-      (tg) => tg.targetGroupId === PRIMARY
-    );
-
-    if (!isProjectWithPrimaryTargetGroup) {
-      console.log(
-        `Adding missing primary school to project ${project.id} ${project.name}`
-      );
-      await prismaClient.project.update({
-        where: {
-          id: project.id,
-        },
-        data: {
-          targetGroups: {
-            create: {
-              targetGroupId: PRIMARY,
-            },
+  try {
+    console.log(`Select all projects with elementary school target group`);
+    const projectsWithElementarySchool = await prismaClient.project.findMany({
+      include: { targetGroups: true },
+      where: {
+        targetGroups: {
+          some: {
+            targetGroupId: ELEMENTARY,
           },
         },
-      });
+      },
+    });
+
+    for (const project of projectsWithElementarySchool) {
+      const isProjectWithPrimaryTargetGroup = project.targetGroups.some(
+        (tg) => tg.targetGroupId === PRIMARY
+      );
+
+      if (!isProjectWithPrimaryTargetGroup) {
+        console.log(
+          `Adding missing primary school to project ${project.id} ${project.name}`
+        );
+
+        await prismaClient.project.update({
+          where: {
+            id: project.id,
+          },
+          data: {
+            targetGroups: {
+              create: {
+                targetGroupId: PRIMARY,
+              },
+            },
+          },
+        });
+      }
     }
-  });
+  } catch (error) {
+    console.error(`Error updating projects: ${error}`);
+    throw error;
+  }
 }
 
 async function main() {
-  console.log(`Update Events`);
-  await updateEvents();
+  try {
+    console.log(`Starting update process`);
+    console.log(`Updating events`);
+    await updateEvents();
 
-  console.log(`Update Projects`);
-  await updateProjects();
+    console.log(`Updating projects`);
+    await updateProjects();
 
-  console.log(`Update TargetGroups`);
-  await removeTargetGroupElementary();
+    console.log(`Deleting target group elementary school`);
+    await removeTargetGroupElementary();
 
-  console.log("Done.");
+    console.log(`Update process completed successfully`);
+  } catch (error) {
+    console.error(`Error during update process: ${error}`);
+    throw error;
+  }
 }
 
 main().catch(console.error);


### PR DESCRIPTION
Beware!: check with **local** supabase

run
$ npx ts-node prisma/scripts/update-targetgroups/index.ts

after migration the targetGroup is removed from base data import, so reseeding won't refill this option
(for testing probably keep "Grundschule" to reseed)

