### PR TITLE
feat: auth/keycloak should be a non layout route

### DIFF
--- a/app/routes/auth/keycloak.tsx
+++ b/app/routes/auth/keycloak.tsx
@@ -20,6 +20,11 @@ function Keycloak() {
   );
   const [urlSearchParams] = useSearchParams();
 
+  // Remove this page from the browser history and instead add document.referrer or landing page ("/")
+  if (typeof history !== "undefined" && typeof document !== "undefined") {
+    history.pushState({}, "", document.referrer || "/");
+  }
+
   React.useEffect(() => {
     async function signIn() {
       const loginRedirect = urlSearchParams.get("login_redirect");

--- a/app/routes/auth/keycloak.tsx
+++ b/app/routes/auth/keycloak.tsx
@@ -1,50 +1,27 @@
-import { json } from "@remix-run/node";
-import { useLoaderData, useSearchParams } from "@remix-run/react";
-import { createBrowserClient } from "@supabase/auth-helpers-remix";
-import React from "react";
+import { type DataFunctionArgs, redirect } from "@remix-run/node";
+import { serverError } from "remix-utils";
+import { createAuthClient } from "~/auth.server";
 
-export const loader = async () => {
-  const env = {
-    SUPABASE_URL: process.env.SUPABASE_URL || "",
-    SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY || "",
-    COMMUNITY_BASE_URL: process.env.COMMUNITY_BASE_URL || "",
-  };
-
-  return json({ env });
-};
-
-function Keycloak() {
-  const { env } = useLoaderData<typeof loader>();
-  const [supabase] = React.useState(() =>
-    createBrowserClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY)
-  );
-  const [urlSearchParams] = useSearchParams();
-
-  // Remove this page from the browser history and instead add document.referrer or landing page ("/")
-  if (typeof history !== "undefined" && typeof document !== "undefined") {
-    history.pushState({}, "", document.referrer || "/");
+export const loader = async ({ request }: DataFunctionArgs) => {
+  const response = new Response();
+  const url = new URL(request.url);
+  const loginRedirect = url.searchParams.get("login_redirect");
+  const authClient = createAuthClient(request, response);
+  const { error, data } = await authClient.auth.signInWithOAuth({
+    provider: "keycloak",
+    options: {
+      scopes: "openid",
+      redirectTo: `${
+        process.env.COMMUNITY_BASE_URL || ""
+      }/auth/keycloak/callback${
+        loginRedirect !== null ? `?login_redirect=${loginRedirect}` : ""
+      }`,
+    },
+  });
+  if (error) {
+    console.log(error);
+    return serverError({ message: error.message });
   }
 
-  React.useEffect(() => {
-    async function signIn() {
-      const loginRedirect = urlSearchParams.get("login_redirect");
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: "keycloak",
-        options: {
-          scopes: "openid",
-          redirectTo: `${env.COMMUNITY_BASE_URL}/auth/keycloak/callback${
-            loginRedirect !== null ? `?login_redirect=${loginRedirect}` : ""
-          }`,
-        },
-      });
-      if (error) {
-        console.log(error);
-      }
-    }
-    signIn();
-  }, [supabase, urlSearchParams, env.COMMUNITY_BASE_URL]);
-
-  return null;
-}
-
-export default Keycloak;
+  return redirect(data.url);
+};


### PR DESCRIPTION
Could not define auth/keycloak as a non layout route as its a leaf route and has a default export component.

Instead i removed it from the browser history on page visit, so when navigating back it will be skipped.
