### PR TITLE
fix: removing yourself as event admin leads to 403 when event is not published

### DIFF
--- a/app/routes/event/$slug/settings/admins/remove-admin.server.ts
+++ b/app/routes/event/$slug/settings/admins/remove-admin.server.ts
@@ -4,6 +4,7 @@ export async function getEventBySlug(slug: string) {
   return await prismaClient.event.findUnique({
     select: {
       id: true,
+      published: true,
       _count: {
         select: {
           admins: true,

--- a/app/routes/event/$slug/settings/admins/remove-admin.tsx
+++ b/app/routes/event/$slug/settings/admins/remove-admin.tsx
@@ -53,7 +53,11 @@ export const action = async (args: DataFunctionArgs) => {
   if (result.success === true) {
     await removeAdminFromEvent(event.id, result.data.profileId);
     if (sessionUser.id === result.data.profileId) {
-      return redirect(`/event/${slug}`);
+      if (event.published) {
+        return redirect(`/event/${slug}`);
+      } else {
+        return redirect("/dashboard");
+      }
     }
   }
   return json(result, { headers: response.headers });


### PR DESCRIPTION
## List issues that are affected

see [Linking a pull request to an issue using a keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

## Checklist

- [X] Tests
- [ ] Documentation

## Request Reviewer (optional)

see [Requesting a pull request review](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review)
