### PR TITLE
fix: navbarmenu not fully visible on some mobile devices

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -449,39 +449,41 @@ export default function App() {
       </head>
 
       <body className={bodyClasses}>
-        <div id="top" className="flex flex-col mv-min-h-screen">
-          <div
-            className={`${
-              showFilters ? "mv-hidden container-lg:mv-block " : " "
-            }${isProjectSettings ? "mv-hidden container-md:mv-block" : ""}`}
-          >
-            <NavBar
-              sessionUserInfo={nextSessionUserInfo}
-              openNavBarMenuKey={openNavBarMenuKey}
-            />
-          </div>
+        <div className={bodyClasses}>
+          <div id="top" className="flex flex-col mv-min-h-screen">
+            <div
+              className={`${
+                showFilters ? "mv-hidden container-lg:mv-block " : " "
+              }${isProjectSettings ? "mv-hidden container-md:mv-block" : ""}`}
+            >
+              <NavBar
+                sessionUserInfo={nextSessionUserInfo}
+                openNavBarMenuKey={openNavBarMenuKey}
+              />
+            </div>
 
-          <div className="mv-flex mv-h-full mv-min-h-screen">
-            <NavBarMenu
-              mode={mode}
-              openNavBarMenuKey={openNavBarMenuKey}
-              username={currentUserInfo?.username}
-              abilities={abilities}
-            />
-            <div className="mv-flex-grow mv-@container">
-              {isIndexRoute === false && isNonAppBaseRoute === false && (
-                <LoginOrRegisterCTA isAnon={mode === "anon"} />
-              )}
-              <div className="flex flex-nowrap min-h-[calc(100dvh - 76px)] xl:min-h-[calc(100dvh - 80px)]">
-                {main}
-                {/* TODO: This should be rendered when the page content is smaller then the screen height. Not only on specific routes like nonAppBaseRoutes*/}
-                {scrollButton}
+            <div className="mv-flex mv-h-full mv-min-h-screen">
+              <NavBarMenu
+                mode={mode}
+                openNavBarMenuKey={openNavBarMenuKey}
+                username={currentUserInfo?.username}
+                abilities={abilities}
+              />
+              <div className="mv-flex-grow mv-@container">
+                {isIndexRoute === false && isNonAppBaseRoute === false && (
+                  <LoginOrRegisterCTA isAnon={mode === "anon"} />
+                )}
+                <div className="flex flex-nowrap min-h-[calc(100dvh - 76px)] xl:min-h-[calc(100dvh - 80px)]">
+                  {main}
+                  {/* TODO: This should be rendered when the page content is smaller then the screen height. Not only on specific routes like nonAppBaseRoutes*/}
+                  {scrollButton}
+                </div>
+                {isIndexRoute ? <Footer /> : null}
               </div>
-              {isIndexRoute ? <Footer /> : null}
             </div>
           </div>
+          <Modal.Root />
         </div>
-        <Modal.Root />
         <ScrollRestoration />
         <Scripts />
         <LiveReload />

--- a/app/routes/__components.tsx
+++ b/app/routes/__components.tsx
@@ -204,7 +204,7 @@ function NavBarMenu(
         isOpen !== null && isOpen !== "false"
           ? "mv-flex mv-flex-col mv-mr-20 xl:mv-mr-0"
           : "mv-hidden xl:mv-flex xl:mv-flex-col"
-      } mv-w-full mv-min-w-full xl:mv-w-[300px] xl:mv-min-w-[300px] mv-h-screen mv-sticky mv-top-0 xl:-mv-mt-28 mv-bg-white mv-z-10`}
+      } mv-w-full mv-min-w-full xl:mv-w-[300px] xl:mv-min-w-[300px] mv-h-dvh mv-max-h-dvh mv-sticky mv-top-0 xl:-mv-mt-28 mv-bg-white mv-z-10`}
     >
       <Link
         to={props.mode !== "anon" ? "/dashboard" : "/"}
@@ -766,7 +766,7 @@ function Opener(props: { openNavBarMenuKey: string }) {
   }
 
   return (
-    <Link to={`?${searchParams.toString()}`} preventScrollReset>
+    <Link to={`?${searchParams.toString()}`}>
       <Icon type="menu" />
     </Link>
   );


### PR DESCRIPTION
overflow hidden does not work on body or html tag in chrome if the meta tag with name="viewport" is present in the head (https://stackoverflow.com/questions/24193272/overflow-xhidden-on-mobile-device-not-working)

Fixed it by using a div inside of the body tag with exactly the same classes as the body tag