### PR TITLE
fix: csp violation from honeypot inputs on client side navigation

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -287,3 +287,7 @@
 .rc-slider-handle-dragging.rc-slider-handle-dragging.rc-slider-handle-dragging {
   box-shadow: 0 0 0 5px #2d6be1 !important;
 }
+
+.honeypot_inputs {
+  display: none;
+}

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -62,8 +62,6 @@ export default async function handleRequest(
   if (process.env.NODE_ENV === "development") {
     // HMR support
     styleSrcElem.push("'unsafe-inline'");
-  } else {
-    styleSrcElem.push(`'nonce-${nonce}'`);
   }
 
   const imgSrc = ["'self'", "data:"];

--- a/app/honeypot.shared.ts
+++ b/app/honeypot.shared.ts
@@ -1,0 +1,1 @@
+export const HONEYPOT_CLASSNAME = "honeypot_inputs";

--- a/app/routes/auth/request-confirmation.tsx
+++ b/app/routes/auth/request-confirmation.tsx
@@ -13,22 +13,22 @@ import {
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
 } from "react-router";
+import { HoneypotInputs } from "remix-utils/honeypot/react";
 import { useHydrated } from "remix-utils/use-hydrated";
+import { checkHoneypot } from "~/honeypot.server";
 import { detectLanguage } from "~/i18n.server";
 import { useIsSubmitting } from "~/lib/hooks/useIsSubmitting";
 import {
   insertComponentsIntoLocale,
   insertParametersIntoLocale,
 } from "~/lib/utils/i18n";
+import { invariantResponse } from "~/lib/utils/response";
 import { languageModuleMap } from "~/locales/.server";
+import { isBotRequest } from "~/utils.server";
 import { createAuthClient, getSessionUser } from "../../auth.server";
 import { requestConfirmation } from "./request-confirmation.server";
 import { createRequestConfirmationSchema } from "./request-confirmation.shared";
-import { checkHoneypot } from "~/honeypot.server";
-import { HoneypotInputs } from "remix-utils/honeypot/react";
-import { isBotRequest } from "~/utils.server";
-import { invariantResponse } from "~/lib/utils/response";
-import { useNonce } from "~/nonce-provider";
+import { HONEYPOT_CLASSNAME } from "~/honeypot.shared";
 
 export async function loader(args: LoaderFunctionArgs) {
   const { request } = args;
@@ -93,7 +93,6 @@ export default function RequestConfirmation() {
   const navigation = useNavigation();
   const isHydrated = useHydrated();
   const isSubmitting = useIsSubmitting();
-  const nonce = useNonce();
   const [urlSearchParams] = useSearchParams();
 
   const loginRedirect = urlSearchParams.get("login_redirect");
@@ -151,7 +150,7 @@ export default function RequestConfirmation() {
               preventScrollReset
               autoComplete="off"
             >
-              <HoneypotInputs nonce={nonce} />
+              <HoneypotInputs className={HONEYPOT_CLASSNAME} />
               <p className="mb-4">{locales.content.description}</p>
               <div className="mb-10">
                 <Input

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -16,6 +16,7 @@ import {
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
 } from "react-router";
+import { HoneypotInputs } from "remix-utils/honeypot/react";
 import { useHydrated } from "remix-utils/use-hydrated";
 import { createAuthClient, getSessionUser } from "~/auth.server";
 import { Accordion } from "~/components-next/Accordion";
@@ -25,10 +26,13 @@ import { PrivateVisibility } from "~/components-next/icons/PrivateVisibility";
 import { PublicVisibility } from "~/components-next/icons/PublicVisibility";
 import { H1 } from "~/components/legacy/Heading/Heading";
 import { RichText } from "~/components/legacy/Richtext/RichText";
+import { checkHoneypot } from "~/honeypot.server";
 import { detectLanguage } from "~/i18n.server";
 import { useIsSubmitting } from "~/lib/hooks/useIsSubmitting";
 import { insertComponentsIntoLocale } from "~/lib/utils/i18n";
+import { invariantResponse } from "~/lib/utils/response";
 import { languageModuleMap } from "~/locales/.server";
+import { isBotRequest } from "~/utils.server";
 import { login } from "./login/index.server";
 import { createLoginSchema } from "./login/index.shared";
 import {
@@ -37,11 +41,7 @@ import {
   getProfileCount,
   getProjectCount,
 } from "./utils.server";
-import { checkHoneypot } from "~/honeypot.server";
-import { HoneypotInputs } from "remix-utils/honeypot/react";
-import { isBotRequest } from "~/utils.server";
-import { invariantResponse } from "~/lib/utils/response";
-import { useNonce } from "~/nonce-provider";
+import { HONEYPOT_CLASSNAME } from "~/honeypot.shared";
 
 export async function loader(args: LoaderFunctionArgs) {
   const { request } = args;
@@ -132,7 +132,6 @@ export default function Index() {
   const navigation = useNavigation();
   const isHydrated = useHydrated();
   const isSubmitting = useIsSubmitting();
-  const nonce = useNonce();
   const [urlSearchParams] = useSearchParams();
 
   const loginRedirect = urlSearchParams.get("login_redirect");
@@ -251,7 +250,7 @@ export default function Index() {
                       method="post"
                       autoComplete="off"
                     >
-                      <HoneypotInputs nonce={nonce} />
+                      <HoneypotInputs className={HONEYPOT_CLASSNAME} />
                       {typeof loginForm.errors !== "undefined" &&
                       loginForm.errors.length > 0 ? (
                         <div>

--- a/app/routes/login/index.tsx
+++ b/app/routes/login/index.tsx
@@ -14,22 +14,22 @@ import {
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
 } from "react-router";
+import { HoneypotInputs } from "remix-utils/honeypot/react";
 import { useHydrated } from "remix-utils/use-hydrated";
 import { ShowPasswordButton } from "~/components-next/ShowPasswordButton";
 import { PrivateVisibility } from "~/components-next/icons/PrivateVisibility";
 import { PublicVisibility } from "~/components-next/icons/PublicVisibility";
 import { RichText } from "~/components/legacy/Richtext/RichText";
+import { checkHoneypot } from "~/honeypot.server";
 import { detectLanguage } from "~/i18n.server";
 import { useIsSubmitting } from "~/lib/hooks/useIsSubmitting";
+import { invariantResponse } from "~/lib/utils/response";
 import { languageModuleMap } from "~/locales/.server";
+import { isBotRequest } from "~/utils.server";
 import { createAuthClient, getSessionUser } from "../../auth.server";
 import { login } from "./index.server";
 import { createLoginSchema } from "./index.shared";
-import { HoneypotInputs } from "remix-utils/honeypot/react";
-import { checkHoneypot } from "~/honeypot.server";
-import { isBotRequest } from "~/utils.server";
-import { invariantResponse } from "~/lib/utils/response";
-import { useNonce } from "~/nonce-provider";
+import { HONEYPOT_CLASSNAME } from "~/honeypot.shared";
 
 export async function loader(args: LoaderFunctionArgs) {
   const { request } = args;
@@ -109,7 +109,6 @@ export default function Index() {
   const navigation = useNavigation();
   const isHydrated = useHydrated();
   const isSubmitting = useIsSubmitting();
-  const nonce = useNonce();
   const [urlSearchParams] = useSearchParams();
 
   const loginRedirect = urlSearchParams.get("login_redirect");
@@ -139,7 +138,7 @@ export default function Index() {
 
   return (
     <Form {...getFormProps(loginForm)} method="post" autoComplete="off">
-      <HoneypotInputs nonce={nonce} />
+      <HoneypotInputs className={HONEYPOT_CLASSNAME} />
       <>
         <div className="w-full mx-auto px-4 @sm:max-w-sm @md:max-w-md @lg:max-w-lg @xl:max-w-xl @xl:px-6 @2xl:max-w-2xl relative">
           <div className="flex flex-col w-full items-center">

--- a/app/routes/register/index.tsx
+++ b/app/routes/register/index.tsx
@@ -15,6 +15,7 @@ import {
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
 } from "react-router";
+import { HoneypotInputs } from "remix-utils/honeypot/react";
 import { useHydrated } from "remix-utils/use-hydrated";
 import { z } from "zod";
 import { createAuthClient, getSessionUser } from "~/auth.server";
@@ -24,20 +25,19 @@ import { FormControl } from "~/components-next/FormControl";
 import { ShowPasswordButton } from "~/components-next/ShowPasswordButton";
 import { PrivateVisibility } from "~/components-next/icons/PrivateVisibility";
 import { PublicVisibility } from "~/components-next/icons/PublicVisibility";
+import { checkHoneypot } from "~/honeypot.server";
 import { detectLanguage } from "~/i18n.server";
 import { useIsSubmitting } from "~/lib/hooks/useIsSubmitting";
 import {
   insertComponentsIntoLocale,
   insertParametersIntoLocale,
 } from "~/lib/utils/i18n";
+import { invariantResponse } from "~/lib/utils/response";
 import { languageModuleMap } from "~/locales/.server";
+import { isBotRequest } from "~/utils.server";
 import { register } from "./index.server";
 import { createRegisterSchema } from "./index.shared";
-import { checkHoneypot } from "~/honeypot.server";
-import { HoneypotInputs } from "remix-utils/honeypot/react";
-import { isBotRequest } from "~/utils.server";
-import { invariantResponse } from "~/lib/utils/response";
-import { useNonce } from "~/nonce-provider";
+import { HONEYPOT_CLASSNAME } from "~/honeypot.shared";
 
 export async function loader(args: LoaderFunctionArgs) {
   const { request } = args;
@@ -102,7 +102,6 @@ export default function Register() {
   const navigation = useNavigation();
   const isHydrated = useHydrated();
   const isSubmitting = useIsSubmitting();
-  const nonce = useNonce();
   const [urlSearchParams] = useSearchParams();
 
   const loginRedirect = urlSearchParams.get("login_redirect");
@@ -194,7 +193,7 @@ export default function Register() {
               preventScrollReset
               autoComplete="off"
             >
-              <HoneypotInputs nonce={nonce} />
+              <HoneypotInputs className={HONEYPOT_CLASSNAME} />
               <p className="mb-4">{locales.form.intro}</p>
               <div className="flex flex-row mb-4">
                 <div className="basis-full @lg:basis-1/2">

--- a/app/routes/reset/index.tsx
+++ b/app/routes/reset/index.tsx
@@ -13,22 +13,22 @@ import {
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
 } from "react-router";
+import { HoneypotInputs } from "remix-utils/honeypot/react";
 import { useHydrated } from "remix-utils/use-hydrated";
+import { checkHoneypot } from "~/honeypot.server";
 import { detectLanguage } from "~/i18n.server";
 import { useIsSubmitting } from "~/lib/hooks/useIsSubmitting";
 import {
   insertComponentsIntoLocale,
   insertParametersIntoLocale,
 } from "~/lib/utils/i18n";
+import { invariantResponse } from "~/lib/utils/response";
 import { languageModuleMap } from "~/locales/.server";
+import { isBotRequest } from "~/utils.server";
 import { createAuthClient, getSessionUser } from "../../auth.server";
 import { requestPasswordChange } from "./index.server";
 import { createRequestPasswordChangeSchema } from "./index.shared";
-import { checkHoneypot } from "~/honeypot.server";
-import { HoneypotInputs } from "remix-utils/honeypot/react";
-import { isBotRequest } from "~/utils.server";
-import { invariantResponse } from "~/lib/utils/response";
-import { useNonce } from "~/nonce-provider";
+import { HONEYPOT_CLASSNAME } from "~/honeypot.shared";
 
 export async function loader(args: LoaderFunctionArgs) {
   const { request } = args;
@@ -94,7 +94,6 @@ export default function Index() {
   const navigation = useNavigation();
   const isHydrated = useHydrated();
   const isSubmitting = useIsSubmitting();
-  const nonce = useNonce();
   const [urlSearchParams] = useSearchParams();
 
   const loginRedirect = urlSearchParams.get("login_redirect");
@@ -176,7 +175,7 @@ export default function Index() {
               preventScrollReset
               autoComplete="off"
             >
-              <HoneypotInputs nonce={nonce} />
+              <HoneypotInputs className={HONEYPOT_CLASSNAME} />
               <p className="mb-4">{locales.form.intro}</p>
               <div className="mb-10">
                 <Input

--- a/app/routes/reset/set-password.tsx
+++ b/app/routes/reset/set-password.tsx
@@ -13,14 +13,18 @@ import {
   type ActionFunctionArgs,
   type LoaderFunctionArgs,
 } from "react-router";
+import { HoneypotInputs } from "remix-utils/honeypot/react";
 import { useHydrated } from "remix-utils/use-hydrated";
 import { z } from "zod";
 import { ShowPasswordButton } from "~/components-next/ShowPasswordButton";
 import { PrivateVisibility } from "~/components-next/icons/PrivateVisibility";
 import { PublicVisibility } from "~/components-next/icons/PublicVisibility";
+import { checkHoneypot } from "~/honeypot.server";
 import { useIsSubmitting } from "~/lib/hooks/useIsSubmitting";
+import { invariantResponse } from "~/lib/utils/response";
 import { languageModuleMap } from "~/locales/.server";
 import { detectLanguage } from "~/root.server";
+import { isBotRequest } from "~/utils.server";
 import {
   createAuthClient,
   getSessionUserOrRedirectPathToLogin,
@@ -28,11 +32,7 @@ import {
 } from "../../auth.server";
 import { setNewPassword } from "./set-password.server";
 import { createSetPasswordSchema } from "./set-password.shared";
-import { checkHoneypot } from "~/honeypot.server";
-import { HoneypotInputs } from "remix-utils/honeypot/react";
-import { isBotRequest } from "~/utils.server";
-import { invariantResponse } from "~/lib/utils/response";
-import { useNonce } from "~/nonce-provider";
+import { HONEYPOT_CLASSNAME } from "~/honeypot.shared";
 
 export async function loader(args: LoaderFunctionArgs) {
   const { request } = args;
@@ -102,7 +102,6 @@ export default function SetPassword() {
   const navigation = useNavigation();
   const isHydrated = useHydrated();
   const isSubmitting = useIsSubmitting();
-  const nonce = useNonce();
   const [urlSearchParams] = useSearchParams();
 
   const loginRedirect = urlSearchParams.get("login_redirect");
@@ -145,7 +144,7 @@ export default function SetPassword() {
       autoComplete="off"
     >
       <>
-        <HoneypotInputs nonce={nonce} />
+        <HoneypotInputs className={HONEYPOT_CLASSNAME} />
         <div className="w-full mx-auto px-4 @sm:max-w-sm @md:max-w-md @lg:max-w-lg @xl:max-w-xl @xl:px-6 @2xl:max-w-2xl relative">
           <div className="flex flex-col w-full items-center">
             <div className="w-full @sm:w-2/3 @md:w-1/2 @2xl:w-1/3">

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,15 +39,15 @@
         "nodemailer": "^8.0.1",
         "pica": "^10.0.1",
         "rc-slider": "^11.1.9",
-        "react": "^19.0.0",
+        "react": "^19.2.7",
         "react-countup": "^6.5.3",
-        "react-dom": "^19.0.0",
+        "react-dom": "^19.2.7",
         "react-easy-crop": "^5.5.7",
         "react-hook-form": "^7.49.2",
         "react-image-crop": "^11.0.1",
         "react-router": "^7.14.1",
         "remix-forms": "^2.2.1",
-        "remix-utils": "^8.1.0",
+        "remix-utils": "^10.0.0",
         "sanitize-html": "^2.11.0",
         "yup": "^1.3.3",
         "zod": "^3.23.8"
@@ -12218,9 +12218,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12239,15 +12239,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-easy-crop": {
@@ -12475,18 +12475,15 @@
       }
     },
     "node_modules/remix-utils": {
-      "version": "8.8.0",
-      "resolved": "https://registry.npmjs.org/remix-utils/-/remix-utils-8.8.0.tgz",
-      "integrity": "sha512-5CR4a3YwPaCoPUHg+O69UMek05tnFMrtQsoXTU4KzsyU7heDO94IFTjKVzEFhi+s+SSo+ebRMxWvjf/QiPpqiQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/remix-utils/-/remix-utils-10.0.0.tgz",
+      "integrity": "sha512-v5voIsJQof6e/1m8te4qyH5YXATWxv+zEgbxd98CwtVxRLCXVc+P9rQ2uDRRYPLCvF9A2ZBOizK0ZTUfm4qJpw==",
       "funding": [
         "https://github.com/sponsors/sergiodxa"
       ],
       "license": "MIT",
-      "dependencies": {
-        "type-fest": "^4.41.0"
-      },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
         "@edgefirst-dev/batcher": "^1.0.0",
@@ -12497,9 +12494,8 @@
         "@standard-schema/spec": "^1.0.0",
         "intl-parse-accept-language": "^1.0.0",
         "is-ip": "^5.0.1",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-router": "^7.0.0",
-        "zod": "^3.22.4"
+        "react": ">=19.2.7",
+        "react-router": "^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edgefirst-dev/batcher": {
@@ -12531,22 +12527,7 @@
         },
         "react-router": {
           "optional": true
-        },
-        "zod": {
-          "optional": true
         }
-      }
-    },
-    "node_modules/remix-utils/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/require-in-the-middle": {

--- a/package.json
+++ b/package.json
@@ -59,15 +59,15 @@
     "nodemailer": "^8.0.1",
     "pica": "^10.0.1",
     "rc-slider": "^11.1.9",
-    "react": "^19.0.0",
+    "react": "^19.2.7",
     "react-countup": "^6.5.3",
-    "react-dom": "^19.0.0",
+    "react-dom": "^19.2.7",
     "react-easy-crop": "^5.5.7",
     "react-hook-form": "^7.49.2",
     "react-image-crop": "^11.0.1",
     "react-router": "^7.14.1",
     "remix-forms": "^2.2.1",
-    "remix-utils": "^8.1.0",
+    "remix-utils": "^10.0.0",
     "sanitize-html": "^2.11.0",
     "yup": "^1.3.3",
     "zod": "^3.23.8"
@@ -127,5 +127,10 @@
   ],
   "lint-staged": {
     "*.{js,css,md,ts,tsx,json}": "prettier --write"
+  },
+  "overrides": {
+    "remix-utils": {
+      "react-router": "$react-router"
+    }
   }
 }


### PR DESCRIPTION
- We had to upgrade remix-utils to v10.0.0 to get the fix. This version depends on react-router >v8 and react >19.2.7. We decided to exclude the react-router upgrade via an npm override in package.json to avoid the mega upgrade. We checked and both subpackages we use from remix-utils do not depend on react-router. React itself was easy to upgrade with no breaking changes.